### PR TITLE
refactor: update script to throw on branches that are not specified o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ Not complying with these conditions will abort the commit. It will display a mes
 npx git-jira-hook commit-msg --debug
 ```
 
+Additionally:
+
+1. Build with `npm run build`
+2. Run test on `build.test.ts`
+
 # Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/bin/commit-msg.ts
+++ b/bin/commit-msg.ts
@@ -10,7 +10,7 @@ const {
   hasCorrectFormat,
   isTicketValid,
   getCommitType,
-  isNonTicketBranch,
+  isBranchOfType,
   getTicketFromBranch,
   addTicketToCommit,
 } = validator;
@@ -51,6 +51,17 @@ async function commitMsg() {
     logger.error(
       'Cannot commit directly to the following branches',
       branchTypes.main.join(', '),
+      true
+    );
+  }
+
+  const isNonTicketBranch = isBranchOfType(branch, branchTypes.nonTicket);
+  const isTicketBranch = isBranchOfType(branch, branchTypes.ticket);
+
+  if (!isNonTicketBranch && !isTicketBranch) {
+    logger.error(
+      'Branch does not match any of the types on the config file',
+      `${branchTypes.ticket.join(', ')}, ${branchTypes.nonTicket.join(', ')}`,
       true
     );
   }
@@ -108,7 +119,7 @@ async function commitMsg() {
 
   logger.warn('Jira ticket is not on the commit message');
 
-  if (isNonTicketBranch(branch, branchTypes.nonTicket)) {
+  if (isNonTicketBranch) {
     logger.success(
       'Working on a non JIRA related branch, no need to add ticket',
       '',

--- a/bin/utils/argv.ts
+++ b/bin/utils/argv.ts
@@ -6,6 +6,9 @@ const argv = yargs(hideBin(process.argv))
     config: { type: 'string', default: '' },
     debug: { type: 'boolean', default: false },
     projectId: { type: 'string' },
+    // For debugging purposes
+    branch: { type: 'string', default: '' },
+    commitMessage: { type: 'string', default: '' },
   })
   .parseSync();
 

--- a/bin/utils/config/getConfigValues.ts
+++ b/bin/utils/config/getConfigValues.ts
@@ -1,6 +1,5 @@
 import type { ErrorObject } from 'ajv';
 import Ajv from 'ajv';
-import merge from 'lodash.merge';
 
 import logger from '../logger';
 import argv from '../argv';
@@ -47,7 +46,7 @@ function isValid(config: UnknownObject): config is Config {
 
 function getConfigValues(config: UnknownObject): ConfigValues {
   if (config && isValid(config)) {
-    return merge(DEFAULT_VALUES, config);
+    return config as ConfigValues;
   }
 
   logger.error('Configuration is not valid. Using default values.');

--- a/bin/utils/git.ts
+++ b/bin/utils/git.ts
@@ -2,7 +2,7 @@ import branchName from 'current-git-branch';
 import fs from 'fs';
 
 import logger from './logger';
-import { COMMIT_MSG_FILE } from './argv';
+import args, { COMMIT_MSG_FILE } from './argv';
 
 /** Writes new content onto the commit message file. */
 function modifyCommitMessage(newContent: string) {
@@ -12,6 +12,12 @@ function modifyCommitMessage(newContent: string) {
 /** Returns the current git branch. */
 function getBranch() {
   const currentBranch = branchName();
+
+  if (args.debug && args.branch) {
+    logger.debug('Passing arg branch for debugging:', args.branch);
+
+    return args.branch;
+  }
 
   logger.debug('Current branch:', currentBranch);
 
@@ -23,7 +29,16 @@ function getCommitMessage() {
   let fullMessage;
 
   try {
-    fullMessage = fs.readFileSync(COMMIT_MSG_FILE, 'utf8').trim();
+    if (args.debug && args.commitMessage) {
+      logger.debug(
+        'Passing arg commitMessage for debugging:',
+        args.commitMessage
+      );
+
+      fullMessage = args.commitMessage;
+    } else {
+      fullMessage = fs.readFileSync(COMMIT_MSG_FILE, 'utf8').trim();
+    }
 
     logger.debug('Commit message:', fullMessage);
 

--- a/bin/utils/validator.ts
+++ b/bin/utils/validator.ts
@@ -77,7 +77,7 @@ function getCommitType(
  * @param branch - Current branch name.
  * @param nonTicketBranches - List of branch types that should have ticket.
  */
-function isNonTicketBranch(branch: string, nonTicketBranches: string[]) {
+function isBranchOfType(branch: string, nonTicketBranches: string[]) {
   const regex = new RegExp(`^\\b(${nonTicketBranches.join('|')})\\b\\/.+?$`);
 
   return !!branch.match(regex);
@@ -158,7 +158,7 @@ export default {
   hasCorrectFormat,
   isTicketValid,
   getCommitType,
-  isNonTicketBranch,
+  isBranchOfType,
   isMainBranch,
   getTicketFromBranch,
   addTicketToCommit,

--- a/hooks.config.json
+++ b/hooks.config.json
@@ -1,12 +1,12 @@
 {
   "projectId": "TEST-JSON",
   "commitTypes": {
-    "ticket": ["feat", "fix", "chore"],
-    "nonTicket": ["other"]
+    "ticket": ["feat", "fix"],
+    "nonTicket": ["other", "refactor"]
   },
   "branchTypes": {
     "main": ["master", "develop"],
-    "ticket": ["feature", "bugfix", "hotfix"],
-    "nonTicket": ["other", "release", "support"]
+    "ticket": ["feature", "fix", "hotfix"],
+    "nonTicket": ["other", "release", "support", "chore", "refactor"]
   }
 }

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -1,0 +1,110 @@
+import { execSync } from 'child_process';
+
+const commitMessage = {
+  ticketWithoutTicket: 'fix: Description',
+  ticketWithTicket: 'fix(TEST-JSON-123): Description',
+  nonTicketWithoutTicket: 'other: description',
+  nonTicketWithTicket: 'other(TEST-JSON-123): description',
+  invalidWithTicket: 'invalid(TEST-JSON-123): description',
+  invalidWithoutTicket: 'invalid: description',
+  badFormat: 'description',
+  special: 'Merge branch',
+};
+
+const branches = {
+  main: 'master',
+
+  ticketWithTicket: 'fix/TEST-JSON-123',
+  ticketWithTicketAndDescription: 'fix/TEST-JSON-123-description',
+  ticketWithoutTicket: 'fix/description',
+
+  nonTicketWithTicket: 'other/TEST-JSON-123-description',
+  nonTicketWithoutTicket: 'other/description',
+
+  invalidWithTicket: 'invalid/TEST-JSON-123-description',
+  invalidWithoutTicket: 'invalid/description',
+};
+
+function runScript(commitMessage: string, branch: string) {
+  return () => {
+    execSync(
+      `node build/commit-msg.cjs commit-msg --debug --commitMessage="${commitMessage}" --branch="${branch}"`
+    );
+  };
+}
+
+describe('commit-msg', () => {
+  it('1. For main branches and invalid branches, it should only pass special commit messages', async () => {
+    for (const message of Object.values(commitMessage)) {
+      if (message === commitMessage.special) {
+        expect(runScript(message, branches.main)).not.toThrow();
+        expect(runScript(message, branches.invalidWithTicket)).not.toThrow();
+        expect(runScript(message, branches.invalidWithoutTicket)).not.toThrow();
+      } else {
+        expect(runScript(message, branches.main)).toThrow();
+        expect(runScript(message, branches.invalidWithTicket)).toThrow();
+        expect(runScript(message, branches.invalidWithoutTicket)).toThrow();
+      }
+    }
+  });
+
+  it('2. For ticket branches with ticket (and/or description), it should pass all valid scenarios', async () => {
+    for (const message of Object.values(commitMessage)) {
+      if (
+        [
+          commitMessage.invalidWithTicket,
+          commitMessage.invalidWithoutTicket,
+          commitMessage.badFormat,
+        ].includes(message)
+      ) {
+        expect(runScript(message, branches.ticketWithTicket)).toThrow();
+        expect(
+          runScript(message, branches.ticketWithTicketAndDescription)
+        ).toThrow();
+      } else {
+        expect(runScript(message, branches.ticketWithTicket)).not.toThrow();
+        expect(
+          runScript(message, branches.ticketWithTicketAndDescription)
+        ).not.toThrow();
+      }
+    }
+  });
+
+  it('3. Almost same case for ticket branch without ticket. It should additionally throw on ticket messages without ticket', async () => {
+    for (const message of Object.values(commitMessage)) {
+      if (
+        [
+          commitMessage.invalidWithTicket,
+          commitMessage.invalidWithoutTicket,
+          commitMessage.badFormat,
+          // should fail because it does not have a way to retrieve the ticket, when it should
+          commitMessage.ticketWithoutTicket,
+        ].includes(message)
+      ) {
+        expect(runScript(message, branches.ticketWithoutTicket)).toThrow();
+      } else {
+        expect(runScript(message, branches.ticketWithoutTicket)).not.toThrow();
+      }
+    }
+  });
+
+  it('4. For non ticket branches (either with or without ticket), it should pass all valid scenarios. Similar to test no. 2', async () => {
+    for (const message of Object.values(commitMessage)) {
+      if (
+        [
+          commitMessage.invalidWithTicket,
+          commitMessage.invalidWithoutTicket,
+          commitMessage.badFormat,
+        ].includes(message)
+      ) {
+        expect(runScript(message, branches.nonTicketWithTicket)).toThrow();
+        expect(runScript(message, branches.nonTicketWithoutTicket)).toThrow();
+      } else {
+        expect(runScript(message, branches.nonTicketWithTicket)).not.toThrow();
+        expect(
+          runScript(message, branches.nonTicketWithoutTicket)
+        ).not.toThrow();
+      }
+    }
+  });
+});

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -5,7 +5,7 @@ const {
   hasCorrectFormat,
   isTicketValid,
   getCommitType,
-  isNonTicketBranch,
+  isBranchOfType,
   isMainBranch,
   getTicketFromBranch,
   addTicketToCommit,
@@ -149,24 +149,24 @@ describe('validator', () => {
     });
   });
 
-  describe('isNonTicketBranch', () => {
+  describe('isBranchOfType', () => {
     const nonTicketBranches = ['other'];
 
     it('should validate for a other branch correctly', () => {
       const branch = 'other/hello';
-      expect(isNonTicketBranch(branch, nonTicketBranches)).toBe(true);
+      expect(isBranchOfType(branch, nonTicketBranches)).toBe(true);
     });
 
     it('should validate for a non other branch correctly', () => {
       const branch = 'feature/hello';
-      const isValid = isNonTicketBranch(branch, nonTicketBranches);
+      const isValid = isBranchOfType(branch, nonTicketBranches);
 
       expect(isValid).toBe(false);
     });
 
     it('should validate for a branch without format', () => {
       const branch = 'hello';
-      const isValid = isNonTicketBranch(branch, nonTicketBranches);
+      const isValid = isBranchOfType(branch, nonTicketBranches);
 
       expect(isValid).toBe(false);
     });


### PR DESCRIPTION
update script to throw on branches that are not specified on the config

additionally, add a test file for the whole script that can be run after building. This is now mandatory before a release